### PR TITLE
committing fixes for #46

### DIFF
--- a/genson/src/main/java/com/owlike/genson/ext/jaxb/JAXBBundle.java
+++ b/genson/src/main/java/com/owlike/genson/ext/jaxb/JAXBBundle.java
@@ -316,8 +316,8 @@ public class JAXBBundle extends GensonBundle {
         if (!TypeUtil.getRawClass(objectType).isAssignableFrom(el.type())) {
           XmlJavaTypeAdapter ad = object.getAnnotation(XmlJavaTypeAdapter.class);
           if (ad == null) 
-          throw new ClassCastException("Inavlid XmlElement annotation, " + objectType
-            + " is not assignable from " + el.type());
+            throw new ClassCastException("Inavlid XmlElement annotation, " + objectType
+              + " is not assignable from " + el.type());
         }
         return el.type();
       } else

--- a/genson/src/test/java/com/owlike/genson/ext/jaxb/JaxbAnnotationsSupportTest.java
+++ b/genson/src/test/java/com/owlike/genson/ext/jaxb/JaxbAnnotationsSupportTest.java
@@ -88,6 +88,11 @@ public class JaxbAnnotationsSupportTest {
   }
 
   @Test
+  public void testXmlJavaTypeAdapterWithXmlElement() {
+    assertEquals("{\"v\":\"0\"}", genson.serialize(new XmlJavaTypeAdapterWithXmlElementBean()));
+  }
+  
+  @Test
   public void testXmlTransientSerialization() {
     XmlTransientContainer container = new XmlTransientContainer();
     container.bean = new XmlTransientBean();
@@ -166,6 +171,12 @@ public class JaxbAnnotationsSupportTest {
     public int v;
   }
 
+  public static class XmlJavaTypeAdapterWithXmlElementBean {
+    @XmlElement(type=String.class)
+    @XmlJavaTypeAdapter(MyXmlAdapter.class)
+    public int v;
+  }
+  
   public static class MyXmlAdapter extends XmlAdapter<String, Integer> {
 
     @Override


### PR DESCRIPTION
This recommended fix ensures that XmlElement annotations are respected along with XmlJavaTypeAdapter annotations during type checking.