### PR TITLE
Fixes ClassCastException with generics and Integer as generic type

### DIFF
--- a/genson/src/main/java/com/owlike/genson/reflect/BeanMutatorAccessorResolver.java
+++ b/genson/src/main/java/com/owlike/genson/reflect/BeanMutatorAccessorResolver.java
@@ -296,15 +296,17 @@ public interface BeanMutatorAccessorResolver {
      * accessors.
      */
     public Trilean isAccessor(Method method, Class<?> fromClass) {
-      String name = method.getName();
-      int len = name.length();
-      if (methodVisibilityFilter.isVisible(method)
-        && ((len > 3 && name.startsWith("get")) || (len > 2 && name.startsWith("is") && (TypeUtil
-        .match(TypeUtil.expandType(method.getGenericReturnType(), fromClass),
-          Boolean.class, false) || TypeUtil.match(
-        method.getGenericReturnType(), boolean.class, false))))
-        && method.getParameterTypes().length == 0)
-        return TRUE;
+      if (!method.isBridge()) {
+        String name = method.getName();
+        int len = name.length();
+        if (methodVisibilityFilter.isVisible(method)
+          && ((len > 3 && name.startsWith("get")) || (len > 2 && name.startsWith("is") && (TypeUtil
+          .match(TypeUtil.expandType(method.getGenericReturnType(), fromClass),
+            Boolean.class, false) || TypeUtil.match(
+          method.getGenericReturnType(), boolean.class, false))))
+          && method.getParameterTypes().length == 0)
+          return TRUE;
+      }
 
       return FALSE;
     }
@@ -322,10 +324,12 @@ public interface BeanMutatorAccessorResolver {
     }
 
     public Trilean isMutator(Method method, Class<?> fromClass) {
-      if (methodVisibilityFilter.isVisible(method) && method.getName().length() > 3
-        && method.getName().startsWith("set") && method.getParameterTypes().length == 1
-        && method.getReturnType() == void.class)
-        return TRUE;
+      if (!method.isBridge()) {
+        if (methodVisibilityFilter.isVisible(method) && method.getName().length() > 3
+          && method.getName().startsWith("set") && method.getParameterTypes().length == 1
+          && method.getReturnType() == void.class)
+          return TRUE;
+      }
 
       return FALSE;
     }


### PR DESCRIPTION
Using generics with Integer as the generic type can cause a "ClassCastException: java.lang.Long cannot be cast to java.lang.Integer".

This problem occurs randomly due to the behavior of the method "Class<?>.getDeclaredMethods" -> "The elements in the array returned are not sorted and are not in any particular order.".
In the case the exception occurs the generated bridge method is used.

A simple isBridge check in the methods "isAccessor" and "isMutator" resolves the problem.