### PR TITLE
Allow to specify Classloader

### DIFF
--- a/genson-scala/src/main/scala/com/owlike/genson/ScalaBeanPropertyFactory.scala
+++ b/genson-scala/src/main/scala/com/owlike/genson/ScalaBeanPropertyFactory.scala
@@ -10,10 +10,12 @@ import scala.reflect.runtime.{universe => u}
 private object ScalaReflectionApiLock
 
 // its a bit ugly to do all this only to handle erased primitive types in scala, but it works to some degree...
-private[genson] class ScalaBeanPropertyFactory extends BeanPropertyFactory {
+private[genson] class ScalaBeanPropertyFactory(classloader: ClassLoader) extends BeanPropertyFactory {
+
+  def this() = this(classOf[ScalaBundle].getClassLoader)
 
   val mirror = ScalaReflectionApiLock.synchronized {
-    u.runtimeMirror(classOf[ScalaBundle].getClassLoader)
+    u.runtimeMirror(classloader)
   }
 
   def createAccessor(name: String, field: Field, ofType: Type, genson: Genson): PropertyAccessor = {

--- a/genson-scala/src/main/scala/com/owlike/genson/ScalaBundle.scala
+++ b/genson-scala/src/main/scala/com/owlike/genson/ScalaBundle.scala
@@ -18,12 +18,7 @@ class ScalaBundle extends GensonBundle {
       .withConverterFactory(ScalaUntypedConverterFactory)
       .withConverterFactory(new TupleConverterFactory())
       .withConverterFactory(new OptionConverterFactory())
-      .withBeanPropertyFactory(createBeanPropertyFactory(builder))
-  }
-
-  def createBeanPropertyFactory(builder: GensonBuilder) = {
-    if (builder.getClassLoader != null) new ScalaBeanPropertyFactory(builder.getClassLoader)
-    else new ScalaBeanPropertyFactory()
+      .withBeanPropertyFactory(new ScalaBeanPropertyFactory(builder.getClassLoader))
   }
 
   def useOnlyConstructorFields(enable: Boolean): ScalaBundle = {

--- a/genson-scala/src/main/scala/com/owlike/genson/ScalaBundle.scala
+++ b/genson-scala/src/main/scala/com/owlike/genson/ScalaBundle.scala
@@ -18,7 +18,12 @@ class ScalaBundle extends GensonBundle {
       .withConverterFactory(ScalaUntypedConverterFactory)
       .withConverterFactory(new TupleConverterFactory())
       .withConverterFactory(new OptionConverterFactory())
-      .withBeanPropertyFactory(new ScalaBeanPropertyFactory())
+      .withBeanPropertyFactory(createBeanPropertyFactory(builder))
+  }
+
+  def createBeanPropertyFactory(builder: GensonBuilder) = {
+    if (builder.getClassLoader != null) new ScalaBeanPropertyFactory(builder.getClassLoader)
+    else new ScalaBeanPropertyFactory()
   }
 
   def useOnlyConstructorFields(enable: Boolean): ScalaBundle = {

--- a/genson/src/main/java/com/owlike/genson/GensonBuilder.java
+++ b/genson/src/main/java/com/owlike/genson/GensonBuilder.java
@@ -60,6 +60,7 @@ public class GensonBuilder {
   private VisibilityFilter methodFilter = VisibilityFilter.PACKAGE_PUBLIC;
   private VisibilityFilter constructorFilter = VisibilityFilter.PACKAGE_PUBLIC;
 
+  private ClassLoader classLoader = null;
   private BeanDescriptorProvider beanDescriptorProvider;
   private Converter<Object> nullConverter;
   private DateFormat dateFormat = SimpleDateFormat.getDateTimeInstance();
@@ -293,6 +294,17 @@ public class GensonBuilder {
     return this;
   }
 
+  /**
+   * Override the default classloader
+   *
+   * @param loader classloader which will be used to load classes while deserializing
+   * @return a reference to this builder
+   */
+  public GensonBuilder withClassLoader(ClassLoader loader) {
+    classLoader = loader;
+    return this;
+  }
+
 
   /**
    * Replaces default {@link com.owlike.genson.reflect.BeanMutatorAccessorResolver
@@ -343,6 +355,10 @@ public class GensonBuilder {
 
   public Map<Type, Deserializer<?>> getDeserializersMap() {
     return Collections.unmodifiableMap(deserializersMap);
+  }
+
+  public ClassLoader getClassLoader() {
+    return classLoader;
   }
 
   /**

--- a/genson/src/main/java/com/owlike/genson/GensonBuilder.java
+++ b/genson/src/main/java/com/owlike/genson/GensonBuilder.java
@@ -60,7 +60,7 @@ public class GensonBuilder {
   private VisibilityFilter methodFilter = VisibilityFilter.PACKAGE_PUBLIC;
   private VisibilityFilter constructorFilter = VisibilityFilter.PACKAGE_PUBLIC;
 
-  private ClassLoader classLoader = null;
+  private ClassLoader classLoader = getClass().getClassLoader();
   private BeanDescriptorProvider beanDescriptorProvider;
   private Converter<Object> nullConverter;
   private DateFormat dateFormat = SimpleDateFormat.getDateTimeInstance();


### PR DESCRIPTION
### Motivation

When using Play Framework there appear to be classloader errors when deserializing case classes which reference other classes in their parameter types.

### Example

It works in play dev mode for the simple cases, i narrowed the error down to the following, this works:

```scala
case class Person(name: String)

val person = genson.fromJson[Person]("{\"name\":\"John Doe\"}")
```

When the case class references another class then it will thrown an error that the class Person was not found:

```scala
case class Person(name: String)
case class PhoneBook(names: List[Person])

val phonebook = genson.fromJson[PhoneBook]("{\"persons\":[{\"name\":\"John Doe\"}]}")
```

## TODO

- [x] Add `withClassLoader` to GensonBuilder
- [x] Check where other classloaders are used and if they should use the classloader specified in the GensonBuilder

