### PR TITLE
Decrease Jersey autodiscoverable level

### DIFF
--- a/genson/src/main/java/com/owlike/genson/ext/jaxrs/JerseyAutoDiscoverable.java
+++ b/genson/src/main/java/com/owlike/genson/ext/jaxrs/JerseyAutoDiscoverable.java
@@ -6,7 +6,7 @@ import javax.annotation.Priority;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.FeatureContext;
 
-@Priority(AutoDiscoverable.DEFAULT_PRIORITY - 100)
+@Priority(AutoDiscoverable.DEFAULT_PRIORITY + 100)
 public class JerseyAutoDiscoverable implements AutoDiscoverable {
 
   @Override


### PR DESCRIPTION
Current `Jersey` autodiscoverable priority is high than default. This can cause `Genson` becomes default serializer for `Jersey` in projects that are using other serializers when you add `Genson` or some custom library that has `Genson` as dependency.
This PR tries to solve this issue.
