### PR TITLE
BUG: Serialization of strings with multiple characters to escape is failing.

### DIFF
--- a/genson/src/main/java/com/owlike/genson/stream/JsonWriter.java
+++ b/genson/src/main/java/com/owlike/genson/stream/JsonWriter.java
@@ -428,7 +428,7 @@ public class JsonWriter implements ObjectWriter {
         continue;
       }
       if (last < i) {
-        sb.append(value, last, i - last);
+        sb.append(value, last, i);
       }
       sb.append(replacement, 0, replacement.length);
       last = i + 1;

--- a/genson/src/test/java/com/owlike/genson/stream/JsonWriterTest.java
+++ b/genson/src/test/java/com/owlike/genson/stream/JsonWriterTest.java
@@ -214,9 +214,16 @@ public class JsonWriterTest {
   }
   
   @Test
-  public void escapeDoubleSpecialCharactersAndWriteName() {
+  public void escapeDoubleSpecialCharacters() {
     String key="\"a\"";
     String escapedKey="\\\"a\\\"";
     assertEquals(escapedKey, new String(JsonWriter.escapeString(key)));
   }
+  
+  @Test
+  public void escapeLongComplicatedString() {
+    String key="\"-->'-->`--><!--#set var=\"i399\" value=\"f1epcssa\"--><!--#set var=\"h88d\" value=\"us9gi9cw\"--><!--#echo var=\"i399\"--><!--#echo var=\"h88d\"-->";
+    String escapedKey="\\\"-->'-->`--><!--#set var=\\\"i399\\\" value=\\\"f1epcssa\\\"--><!--#set var=\\\"h88d\\\" value=\\\"us9gi9cw\\\"--><!--#echo var=\\\"i399\\\"--><!--#echo var=\\\"h88d\\\"-->";
+    assertEquals(escapedKey, new String(JsonWriter.escapeString(key)));
+  }  
 }

--- a/genson/src/test/java/com/owlike/genson/stream/JsonWriterTest.java
+++ b/genson/src/test/java/com/owlike/genson/stream/JsonWriterTest.java
@@ -212,4 +212,11 @@ public class JsonWriterTest {
 
     assertEquals("{\"foo\\\"bar\":true,\"bar\\\"foo\":1}", sw.toString());
   }
+  
+  @Test
+  public void escapeDoubleSpecialCharactersAndWriteName() {
+    String key="\"a\"";
+    String escapedKey="\\\"a\\\"";
+    assertEquals(escapedKey, new String(JsonWriter.escapeString(key)));
+  }
 }


### PR DESCRIPTION
JsonWriter.escapeString works well for key '"a"', however, fails for 'a"a"'.
See unit test cases and fix.