### PR TITLE
Fix for #130: Class mappings for ValueType enum should be mutable

### DIFF
--- a/genson/src/main/java/com/owlike/genson/ext/jsr353/JSR353Bundle.java
+++ b/genson/src/main/java/com/owlike/genson/ext/jsr353/JSR353Bundle.java
@@ -37,6 +37,17 @@ public class JSR353Bundle extends GensonBundle {
     });
   }
 
+  public JSR353Bundle preferJsonpTypes() {
+    com.owlike.genson.stream.ValueType.ARRAY.setDefaultClass(JsonArray.class);
+    com.owlike.genson.stream.ValueType.BOOLEAN.setDefaultClass(JsonValue.class);
+    com.owlike.genson.stream.ValueType.DOUBLE.setDefaultClass(JsonNumber.class);
+    com.owlike.genson.stream.ValueType.INTEGER.setDefaultClass(JsonNumber.class);
+    com.owlike.genson.stream.ValueType.NULL.setDefaultClass(JsonValue.class);
+    com.owlike.genson.stream.ValueType.OBJECT.setDefaultClass(JsonObject.class);
+    com.owlike.genson.stream.ValueType.STRING.setDefaultClass(JsonString.class);
+    return this;
+  }
+  
   public class JsonValueConverter implements Converter<JsonValue> {
 
     @Override

--- a/genson/src/main/java/com/owlike/genson/stream/ValueType.java
+++ b/genson/src/main/java/com/owlike/genson/stream/ValueType.java
@@ -12,9 +12,13 @@ public enum ValueType {
   BOOLEAN(Boolean.class),
   NULL(null);
 
-  private final Class<?> clazz;
+  private Class<?> clazz;
 
   ValueType(Class<?> clazz) {
+    this.clazz = clazz;
+  }
+
+  public void setDefaultClass(Class<?> clazz) {
     this.clazz = clazz;
   }
 

--- a/genson/src/test/java/com/owlike/genson/ext/jsr353/JsonValueTest.java
+++ b/genson/src/test/java/com/owlike/genson/ext/jsr353/JsonValueTest.java
@@ -1,15 +1,17 @@
 package com.owlike.genson.ext.jsr353;
 
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonString;
+import javax.json.*;
 
 import com.owlike.genson.GensonBuilder;
+import com.owlike.genson.stream.ValueType;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 import com.owlike.genson.Genson;
+
+import java.util.List;
+import java.util.Map;
 
 public class JsonValueTest {
   private final Genson genson = new GensonBuilder().withBundle(new JSR353Bundle()).create();
@@ -66,6 +68,46 @@ public class JsonValueTest {
     assertEquals(object, actual.obj);
     assertEquals(object.getJsonString("key"), actual.str);
   }
+
+  @Test
+  public void testPreferJsonpTypes() {
+    try {
+      Genson genson = new GensonBuilder().withBundle(new JSR353Bundle().preferJsonpTypes()).create();
+      JsonObject obj = (JsonObject) genson.deserialize("{\n" +
+              "  \"array\": [1, 2, 3],\n" +
+              "  \"true\": true,\n" +
+              "  \"false\": false,\n" +
+              "  \"int\": 42,\n" +
+              "  \"double\": 98.6,\n" +
+              "  \"string\": \"some text\",\n" +
+              "  \"obj\": {\"name\": \"Homer\"},\n" +
+              "  \"null\": null\n" +
+              "}", Object.class);
+
+      assertTrue(obj.get("array") instanceof JsonArray);
+      assertEquals(3, obj.getJsonArray("array").size());
+      assertTrue(obj.get("int") instanceof JsonNumber);
+      assertEquals(42, obj.getJsonNumber("int").intValue());
+      assertTrue(obj.get("double") instanceof JsonNumber);
+      assertEquals(98.6d, obj.getJsonNumber("double").doubleValue(), 1e-200);
+      assertTrue(obj.get("string") instanceof JsonString);
+      assertEquals("some text", obj.getJsonString("string").getString());
+      assertTrue(obj.get("obj") instanceof JsonObject);
+      assertEquals("Homer", obj.getJsonObject("obj").getString("name"));
+      assertEquals(JsonValue.TRUE, obj.get("true"));
+      assertEquals(JsonValue.FALSE, obj.get("false"));
+      assertEquals(JsonValue.NULL, obj.get("null"));
+    } finally {
+      ValueType.ARRAY.setDefaultClass(List.class);
+      ValueType.BOOLEAN.setDefaultClass(Boolean.class);
+      ValueType.DOUBLE.setDefaultClass(Double.class);
+      ValueType.INTEGER.setDefaultClass(Long.class);
+      ValueType.NULL.setDefaultClass(null);
+      ValueType.OBJECT.setDefaultClass(Map.class);
+      ValueType.STRING.setDefaultClass(String.class);
+    }
+  }
+
 
   public static class Bean {
     private JsonString str;


### PR DESCRIPTION
The change is trivial, but it makes it possible to do some things that are currently very hard to do.