### PR TITLE
Better control for class metadata ser/de and JsonP extension

### DIFF
--- a/genson/src/main/java/com/owlike/genson/annotation/HandleClassMetadata.java
+++ b/genson/src/main/java/com/owlike/genson/annotation/HandleClassMetadata.java
@@ -27,5 +27,13 @@ import java.lang.annotation.Target;
 @Inherited
 @Documented
 public @interface HandleClassMetadata {
+    /**
+     * Set to false if you want to let the existing mechanism handle the class metadata for you.
+     */
+    boolean serialization() default true;
 
+    /**
+     * @see #serialization()
+     */
+    boolean deserialization() default true;
 }

--- a/genson/src/main/java/com/owlike/genson/convert/DefaultConverters.java
+++ b/genson/src/main/java/com/owlike/genson/convert/DefaultConverters.java
@@ -986,6 +986,7 @@ public final class DefaultConverters {
     private UntypedConverterFactory() {
     }
 
+    @HandleClassMetadata(serialization = true, deserialization = false)
     public final static class UntypedConverter implements Converter<Object> {
       final static UntypedConverter instance = new UntypedConverter();
 


### PR DESCRIPTION
- Ability to disable class metadata only for ser or deser via `@HandleClassMetadata(serialization=true/false, deserialization=true/false)`
- By default prevent the `ClassMetadataConverter` to kick in when we ser/de statically typed JsonValues
- Allow to use JsonValueConverter as default when the type is unknwon and let it leverage ClassMetadataConverter when there is class info.