### PR TITLE
Java 17 Compatibility

### DIFF
--- a/genson-scala/pom.xml
+++ b/genson-scala/pom.xml
@@ -14,8 +14,8 @@
   <description>Genson extension for Scala language</description>
 
   <properties>
-    <scala.version>2.11</scala.version>
-    <scala.range.version>2.11.11</scala.range.version>
+    <scala.version>2.12</scala.version>
+    <scala.range.version>2.12.15</scala.range.version>
   </properties>
 
   <dependencies>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
-      <version>5.0.3</version>
+      <version>9.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/genson/pom.xml
+++ b/genson/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-commons</artifactId>
-      <version>5.0.3</version>
+      <version>9.2</version>
       <optional>true</optional>
     </dependency>
 
@@ -37,6 +37,13 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.0.1</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>2.3.3</version>
       <optional>true</optional>
     </dependency>
 
@@ -129,7 +136,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>8.1.8.v20121106</version>
+      <version>9.4.17.v20190418</version>
       <scope>test</scope>
     </dependency>
 

--- a/genson/src/main/java/com/owlike/genson/reflect/ASMCreatorParameterNameResolver.java
+++ b/genson/src/main/java/com/owlike/genson/reflect/ASMCreatorParameterNameResolver.java
@@ -132,7 +132,7 @@ public final class ASMCreatorParameterNameResolver implements PropertyNameResolv
     public ClassConstructorsVisitor(Class<?> forClass,
                                     Map<Constructor<?>, String[]> ctrParameterNames,
                                     Map<Method, String[]> methodParameterNames) {
-      super(Opcodes.ASM5);
+      super(Opcodes.ASM7);
       this.forClass = forClass;
       this.ctrParameterNames = ctrParameterNames;
       this.methodParameterNames = methodParameterNames;
@@ -161,7 +161,7 @@ public final class ASMCreatorParameterNameResolver implements PropertyNameResolv
 
     public BaseMethodVisitor(Class<?> forClass, boolean ztatic, String desc,
                              Map<Method, String[]> parameterNamesMap) {
-      super(Opcodes.ASM5);
+      super(Opcodes.ASM7);
       this.forClass = forClass;
       this.ztatic = ztatic;
       paramTypes = Type.getArgumentTypes(desc);

--- a/genson/src/main/java/com/owlike/genson/reflect/VisibilityFilter.java
+++ b/genson/src/main/java/com/owlike/genson/reflect/VisibilityFilter.java
@@ -70,7 +70,14 @@ public final class VisibilityFilter {
    * @return true if this member is visible according to this filter.
    */
   public final boolean isVisible(Member member) {
-    return isVisible(member.getModifiers());
+    Class<?> clazz = member.getDeclaringClass();
+    String className = clazz.getName();
+    if(className.startsWith("java.") || className.startsWith("javax.")){
+      return Modifier.isPublic(member.getModifiers());
+    }
+    else{
+      return isVisible(member.getModifiers());
+    }
   }
 
   public final boolean isVisible(int modifiers) {

--- a/genson/src/test/java/com/owlike/genson/JsonSerDeserSymetricTest.java
+++ b/genson/src/test/java/com/owlike/genson/JsonSerDeserSymetricTest.java
@@ -149,10 +149,10 @@ public class JsonSerDeserSymetricTest {
 
     // we first deserialize the original data and ensure that genson deserialized it exactly as
     // jackson
-    Tweet[] jacksonTweets = mapper.readValue(ClassLoader.class
-      .getResourceAsStream("/TWEETS.json"), Tweet[].class);
-    Tweet[] gensonTweets = genson.deserialize(new InputStreamReader(ClassLoader.class
-      .getResourceAsStream("/TWEETS.json")), Tweet[].class);
+    Tweet[] jacksonTweets = mapper.readValue(ClassLoader
+      .getSystemResourceAsStream("TWEETS.json"), Tweet[].class);
+    Tweet[] gensonTweets = genson.deserialize(new InputStreamReader(ClassLoader
+      .getSystemResourceAsStream("TWEETS.json")), Tweet[].class);
     assertArrayEquals(jacksonTweets, gensonTweets);
 
     // and then we serialize it and try to deserialize again and match again what was
@@ -170,10 +170,10 @@ public class JsonSerDeserSymetricTest {
     Genson genson = getGenson();
 
     // same test as before...
-    Feed jacksonShortFeed = mapper.readValue(ClassLoader.class
-      .getResourceAsStream("/READER_SHORT.json"), Feed.class);
-    Feed gensonShortFeed = genson.deserialize(new InputStreamReader(ClassLoader.class
-      .getResourceAsStream("/READER_SHORT.json")), Feed.class);
+    Feed jacksonShortFeed = mapper.readValue(ClassLoader
+      .getSystemResourceAsStream("READER_SHORT.json"), Feed.class);
+    Feed gensonShortFeed = genson.deserialize(new InputStreamReader(ClassLoader
+      .getSystemResourceAsStream("READER_SHORT.json")), Feed.class);
     assertEquals(jacksonShortFeed, gensonShortFeed);
     String shortFeedString = genson.serialize(gensonShortFeed);
     gensonShortFeed = genson.deserialize(shortFeedString, Feed.class);
@@ -187,10 +187,10 @@ public class JsonSerDeserSymetricTest {
     Genson genson = getGenson();
 
     // and again for the long reader data...
-    Feed jacksonLongFeed = mapper.readValue(ClassLoader.class
-      .getResourceAsStream("/READER_LONG.json"), Feed.class);
-    Feed gensonLongFeed = genson.deserialize(new InputStreamReader(ClassLoader.class
-      .getResourceAsStream("/READER_LONG.json")), Feed.class);
+    Feed jacksonLongFeed = mapper.readValue(ClassLoader
+      .getSystemResourceAsStream("READER_LONG.json"), Feed.class);
+    Feed gensonLongFeed = genson.deserialize(new InputStreamReader(ClassLoader
+      .getSystemResourceAsStream("READER_LONG.json")), Feed.class);
     assertEquals(jacksonLongFeed, gensonLongFeed);
     String longFeedString = genson.serialize(gensonLongFeed);
     gensonLongFeed = genson.deserialize(longFeedString, Feed.class);
@@ -241,10 +241,10 @@ public class JsonSerDeserSymetricTest {
     JsonMappingException, IOException {
     ObjectMapper mapper = new ObjectMapper();
     Genson genson = new Genson();
-    MediaContent jacksonContent = mapper.readValue(ClassLoader.class
-      .getResourceAsStream("/MEDIA_CONTENT.json"), MediaContent.class);
-    MediaContent gensonContent = genson.deserialize(new InputStreamReader(ClassLoader.class
-      .getResourceAsStream("/MEDIA_CONTENT.json")), MediaContent.class);
+    MediaContent jacksonContent = mapper.readValue(ClassLoader
+      .getSystemResourceAsStream("MEDIA_CONTENT.json"), MediaContent.class);
+    MediaContent gensonContent = genson.deserialize(new InputStreamReader(ClassLoader
+      .getSystemResourceAsStream("MEDIA_CONTENT.json")), MediaContent.class);
     assertEquals(jacksonContent, gensonContent);
     String json = genson.serialize(gensonContent);
     gensonContent = genson.deserialize(json, MediaContent.class);

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <additionalOptions>-Xdoclint:none</additionalOptions>
 
     <!-- Be clear about the required JDK build version. -->
-    <jdk.version>1.8</jdk.version>
+    <jdk.version>17</jdk.version>
 
   </properties>
 


### PR DESCRIPTION
These are the minimum changes needed for Java 17 to address the reflection issues specified in #173 

I think only the first commit is actually needed to handle the reflection issues.  The other commits were necessary to build using jdk 17.  They could be removed but I left them in case it makes sense to create a separate java 17 specific artifact


A couple notes:

- Non-public members are ignored for classes under 'java.*' and 'javax.*' packages
- Since Java 11(?), getResourceAsStream only looks within the module of the class which caused a couple tests to fail.  Using getSystemResourceAsStream seems to work
- ASM needed to be updated to Opcode version 7 (minimum needed for Java 11).  Note that Opcode 8 and 9 is available
- Scala needed to be updated in order to compile. I updated to version 2.12.  Version 2.13 is more current but it removed CanBuildFrom and I have too little knowledge of Scala to know the proper way of updating the code