### PR TITLE
Ignore non public members for base java classes

### DIFF
--- a/genson/src/main/java/com/owlike/genson/reflect/VisibilityFilter.java
+++ b/genson/src/main/java/com/owlike/genson/reflect/VisibilityFilter.java
@@ -73,11 +73,12 @@ public final class VisibilityFilter {
     Class<?> clazz = member.getDeclaringClass();
     String className = clazz.getName();
     if(className.startsWith("java.") || className.startsWith("javax.")){
-      return Modifier.isPublic(member.getModifiers());
+      if(!Modifier.isPublic(member.getModifiers())){
+        return false;
+      }
     }
-    else{
-      return isVisible(member.getModifiers());
-    }
+
+    return isVisible(member.getModifiers());
   }
 
   public final boolean isVisible(int modifiers) {

--- a/genson/src/main/java/com/owlike/genson/reflect/VisibilityFilter.java
+++ b/genson/src/main/java/com/owlike/genson/reflect/VisibilityFilter.java
@@ -70,15 +70,22 @@ public final class VisibilityFilter {
    * @return true if this member is visible according to this filter.
    */
   public final boolean isVisible(Member member) {
-    Class<?> clazz = member.getDeclaringClass();
-    String className = clazz.getName();
-    if(className.startsWith("java.") || className.startsWith("javax.")){
-      if(!Modifier.isPublic(member.getModifiers())){
-        return false;
+    boolean visible = isVisible(member.getModifiers());
+
+    //Due to recent changes involving reflection access to base java classes,
+    //we need to perform an additional check to ensure that members belonging
+    //to java/javax packages are public. Non-public members will always be considered not visible
+    if(visible){
+      Class<?> clazz = member.getDeclaringClass();
+      String className = clazz.getName();
+      if(className.startsWith("java.") || className.startsWith("javax.")){
+        if(!Modifier.isPublic(member.getModifiers())){
+          visible = false;
+        }
       }
     }
 
-    return isVisible(member.getModifiers());
+    return visible;
   }
 
   public final boolean isVisible(int modifiers) {

--- a/genson/src/main/java/com/owlike/genson/reflect/VisibilityFilter.java
+++ b/genson/src/main/java/com/owlike/genson/reflect/VisibilityFilter.java
@@ -70,7 +70,14 @@ public final class VisibilityFilter {
    * @return true if this member is visible according to this filter.
    */
   public final boolean isVisible(Member member) {
-    return isVisible(member.getModifiers());
+    Class<?> clazz = member.getDeclaringClass();
+    String className = clazz.getName();
+    if(className.startsWith("java.") || className.startsWith("javax.")){
+      return Modifier.isPublic(member.getModifiers());
+    }
+    else{
+      return isVisible(member.getModifiers());
+    }
   }
 
   public final boolean isVisible(int modifiers) {


### PR DESCRIPTION
This change causes genson to ignore non-public members for classes in java/javax packages.  Public members are still checked for other modifiers specified by the filter.  This should fix the reflection issues specified in #173 

An alternative fix is provided in #178 