### PR TITLE
Wrap calls to setAccessible in try-catch

### DIFF
--- a/genson/src/main/java/com/owlike/genson/reflect/PropertyAccessor.java
+++ b/genson/src/main/java/com/owlike/genson/reflect/PropertyAccessor.java
@@ -49,19 +49,25 @@ public abstract class PropertyAccessor extends BeanProperty implements Comparabl
 
   public static class MethodAccessor extends PropertyAccessor {
     protected final Method _getter;
+    protected boolean accessible = true;
 
     public MethodAccessor(String name, Method getter, Type type, Class<?> concreteClass) {
       super(name, type, getter.getDeclaringClass(), concreteClass, getter.getAnnotations(), getter.getModifiers());
       this._getter = getter;
       if (!_getter.isAccessible()) {
-        _getter.setAccessible(true);
+        try{
+          _getter.setAccessible(true);
+        }
+        catch(Exception e){
+          accessible = false;
+        }
       }
     }
 
     @Override
     public Object access(final Object target) {
       try {
-        return _getter.invoke(target);
+        return accessible ? _getter.invoke(target) : null;
       } catch (IllegalArgumentException e) {
         throw couldNotAccess(e);
       } catch (IllegalAccessException e) {
@@ -84,19 +90,25 @@ public abstract class PropertyAccessor extends BeanProperty implements Comparabl
 
   public static class FieldAccessor extends PropertyAccessor {
     protected final Field _field;
+    protected boolean accessible = true;
 
     public FieldAccessor(String name, Field field, Type type, Class<?> concreteClass) {
       super(name, type, field.getDeclaringClass(), concreteClass, field.getAnnotations(), field.getModifiers());
       this._field = field;
       if (!_field.isAccessible()) {
-        _field.setAccessible(true);
+        try{
+          _field.setAccessible(true);
+        }
+        catch(Exception e){
+          accessible = false;
+        }
       }
     }
 
     @Override
     public Object access(final Object target) {
       try {
-        return _field.get(target);
+        return accessible ? _field.get(target) : null;
       } catch (IllegalArgumentException e) {
         throw couldNotAccess(e);
       } catch (IllegalAccessException e) {

--- a/genson/src/main/java/com/owlike/genson/reflect/PropertyMutator.java
+++ b/genson/src/main/java/com/owlike/genson/reflect/PropertyMutator.java
@@ -52,19 +52,27 @@ public abstract class PropertyMutator extends BeanProperty implements Comparable
 
   public static class MethodMutator extends PropertyMutator {
     protected final Method _setter;
+    protected boolean accessible = true;
 
     public MethodMutator(String name, Method setter, Type type, Class<?> concreteClass) {
       super(name, type, setter.getDeclaringClass(), concreteClass, setter.getAnnotations(), setter.getModifiers());
       this._setter = setter;
       if (!_setter.isAccessible()) {
-        _setter.setAccessible(true);
+        try{
+          _setter.setAccessible(true);
+        }
+        catch(Exception e){
+          accessible = false;
+        }
       }
     }
 
     @Override
     public void mutate(Object target, Object value) {
       try {
-        _setter.invoke(target, value);
+        if(accessible){
+          _setter.invoke(target, value);
+        }
       } catch (IllegalArgumentException e) {
         throw couldNotMutate(e);
       } catch (IllegalAccessException e) {
@@ -87,19 +95,27 @@ public abstract class PropertyMutator extends BeanProperty implements Comparable
 
   public static class FieldMutator extends PropertyMutator {
     protected final Field _field;
+    protected boolean accessible = true;
 
     public FieldMutator(String name, Field field, Type type, Class<?> concreteClass) {
       super(name, type, field.getDeclaringClass(), concreteClass, field.getAnnotations(), field.getModifiers());
       this._field = field;
       if (!_field.isAccessible()) {
-        _field.setAccessible(true);
+        try{
+          _field.setAccessible(true);
+        }
+        catch(Exception e){
+          accessible = false;
+        }
       }
     }
 
     @Override
     public void mutate(Object target, Object value) {
       try {
-        _field.set(target, value);
+        if(accessible){
+          _field.set(target, value);
+        }
       } catch (IllegalArgumentException e) {
         throw couldNotMutate(e);
       } catch (IllegalAccessException e) {


### PR DESCRIPTION
This is an alternative fix for #173 where the call to setAccessible is wrapped in a try-catch.  I am catching `Exception` instead of `InaccessibleObjectException` since the latter is only available since Java 9.  This way, the code remains backwards compatible with Java 8